### PR TITLE
Mocker, pytest mark

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - pip
   - pybind11
   - pytest
+  - pytest-mock
   - python=3.6
   - scikit-image=0.14.0
   - scikit-learn

--- a/src/aspyre/apple/picking.py
+++ b/src/aspyre/apple/picking.py
@@ -23,19 +23,16 @@ class Picker:
     def __init__(self, particle_size, max_size, min_size, query_size, tau1, tau2, moa,
                  container_size, filename, output_directory):
 
-        self.particle_size = int(particle_size / 2)
-        self.max_size = int(max_size / 2)
-        self.min_size = int(min_size / 2)
-        self.query_size = int(query_size / 2)
-        self.query_size -= self.query_size % 2
+        self.particle_size = particle_size // 2
+        self.max_size = max_size // 2
+        self.min_size = min_size // 2
+        self.query_size = query_size // 2
         self.tau1 = tau1
         self.tau2 = tau2
-        self.moa = int(moa / 2)
-        self.container_size = int(container_size / 2)
+        self.moa = moa // 2
+        self.container_size = container_size // 2
         self.filename = filename
         self.output_directory = output_directory
-
-        self.query_size -= self.query_size % 2
 
     def read_mrc(self):
         """Gets and preprocesses micrograph.

--- a/tests/test_apple.py
+++ b/tests/test_apple.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 from aspyre.apple.apple import Apple
+import pytest
 
 import os.path
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'saved_test_data', 'mrc_files')
@@ -12,6 +13,7 @@ class ApplePickerTestCase(TestCase):
     def tearDown(self):
         pass
 
+    @pytest.mark.acceptance
     def testPickCenters(self):
         # 504 particles with the following centers
         centers = {

--- a/tests/test_picker.py
+++ b/tests/test_picker.py
@@ -1,0 +1,97 @@
+import pytest
+import numpy as np
+from numpy.testing import assert_array_equal as aae
+from aspyre.apple.picking import Picker
+
+
+@pytest.fixture
+def picker():
+    '''
+    A standard picker
+    '''
+    return Picker(
+        particle_size=78,
+        max_size=156,
+        min_size=19,
+        query_size=52,
+        tau1=710,
+        tau2=7100,
+        moa=7,
+        container_size=450,
+        filename='test',
+        output_directory='out_dir'
+    )
+
+
+def test_init(picker):
+    assert picker.particle_size == 39
+    assert picker.max_size == 78
+    assert picker.min_size == 9
+    assert picker.query_size == 26
+    assert picker.tau1 == 710
+    assert picker.tau2 == 7100
+    assert picker.moa == 3
+    assert picker.container_size == 225
+    assert picker.filename == 'test'
+    assert picker.output_directory == 'out_dir'
+
+    # Picker with odd numbers for parameters that are truncated
+    odd_picker = Picker(
+        particle_size=79,
+        max_size=157,
+        min_size=20,
+        query_size=53,
+        tau1=710,
+        tau2=7100,
+        moa=7,
+        container_size=451,
+        filename='test',
+        output_directory='out_dir'
+    )
+
+    assert odd_picker.particle_size == 39
+    assert odd_picker.max_size == 78
+    assert odd_picker.min_size == 10
+    assert odd_picker.query_size == 26
+    assert odd_picker.moa == 3
+    assert odd_picker.container_size == 225
+    assert odd_picker.tau1 == 710
+    assert odd_picker.tau2 == 7100
+    assert odd_picker.filename == 'test'
+    assert odd_picker.output_directory == 'out_dir'
+
+
+def test_read_mrc(picker, mocker):
+    # don't want the config to affect these
+    mocker.patch('src.aspyre.apple.picking.config.apple.mrc.margin_top', 1)
+    mocker.patch('src.aspyre.apple.picking.config.apple.mrc.margin_bottom', 2)
+    mocker.patch('src.aspyre.apple.picking.config.apple.mrc.margin_left', 3)
+    mocker.patch('src.aspyre.apple.picking.config.apple.mrc.margin_right', 4)
+
+    mocker.patch('src.aspyre.apple.picking.config.apple.mrc.shrink_factor', 5)
+    # don't want to test these
+    mock_resize = mocker.patch('src.aspyre.apple.picking.misc.imresize',
+                               side_effect=lambda x, _, mode, interp: x)
+    mock_corr = mocker.patch('src.aspyre.apple.picking.signal.correlate',
+                             side_effect=lambda x, _, _2: x)
+
+    # use a standard input
+    mock_mrc = mocker.MagicMock()
+    mock_mrc.__enter__().data = np.ones((16, 10))
+    mock_mrc_open = mocker.patch('src.aspyre.apple.picking.mrcfile.open',
+                                 return_value=mock_mrc)
+
+    result = picker.read_mrc()
+    mock_mrc_open.assert_called_once_with('test',
+                                          mode='r+',
+                                          permissive=True)
+    mock_resize.assert_called_once_with(mocker.ANY,
+                                        1/5,
+                                        mode='F',
+                                        interp='cubic')
+    mock_corr.assert_called_once_with(mocker.ANY,
+                                      mocker.ANY,
+                                      'same')
+
+    # now effectively testing size changes, should be min(16 - 3, 10 - 7) = 3x3
+    aae(result, np.ones((3, 3)))


### PR DESCRIPTION
Added mocker and a sample test of picker.py
With picker, replaced int casting with integer division from python 3
and removed no op -= query_size % 2 lines
Added an acceptance mark for the long-running test_apple function
Can run all tests except acceptance with:
`pytest -m "not acceptance"`